### PR TITLE
Add default empty string as source argument

### DIFF
--- a/source/wrappers/python/pyuda/_client.py
+++ b/source/wrappers/python/pyuda/_client.py
@@ -160,7 +160,7 @@ class Client(with_metaclass(ClientMeta, object)):
             signals.append(self._unpack(result, time_first, time_last))
         return signals
 
-    def get(self, signal, source, time_first=False, time_last=False, **kwargs):
+    def get(self, signal, source="", time_first=False, time_last=False, **kwargs):
         """
         UDA get data method.
 


### PR DESCRIPTION
Removes the need to run:
> client.get("func::func()", "")
instead, allowing:
> client.get("func::func()")
to perform the same functionality as before.
> client.get("func::func()", "")
is still valid and runs as before, but the spurious empty string as second argument is no longer necessary.

This has no impact on the ability to pass a string as the second argument.
> client.get("signal", "source")
is still valid, as it always was.
> client.get("signal", source="source")
is also valid, and also always was.