### PR TITLE
Bug: Various order of plugin libraries in plugin leads to various results

### DIFF
--- a/cmake/plugins.cmake
+++ b/cmake/plugins.cmake
@@ -2,12 +2,17 @@ macro( filter_lib_list INPUT OUTPUT GOOD BAD )
   set( LIB_LST ${INPUT} )
   set( USE_LIB YES )
   foreach( ELEMENT IN LISTS LIB_LST )
+    # A library is defines as:
+    # * <build_type> <lib>
+    # * <lib>
     if( "${ELEMENT}" STREQUAL "general" OR "${ELEMENT}" STREQUAL "${GOOD}" )
       set( USE_LIB YES )
     elseif( "${ELEMENT}" STREQUAL "${BAD}" )
       set( USE_LIB NO )
     elseif( USE_LIB )
       list( APPEND ${OUTPUT} ${ELEMENT} )
+    else()
+      set( USE_LIB YES )
     endif()
   endforeach()
 endmacro( filter_lib_list )
@@ -81,7 +86,7 @@ macro( uda_plugin )
   foreach( DEF ${PLUGIN_EXTRA_DEFINITIONS} )
     add_definitions( ${DEF} )
   endforeach()
-  
+
   set( LIBRARIES client-shared plugins-shared ${OPENSSL_LIBRARIES} )
   if( ENABLE_CAPNP )
     set( LIBRARIES ${LIBRARIES} serialisation-static )
@@ -97,12 +102,12 @@ macro( uda_plugin )
   else()
     set( LIBRARIES ${LIBRARIES} dl stdc++ )
   endif()
-  
-  filter_lib_list( "${PLUGIN_EXTRA_LINK_LIBS}" FILTERED_LINK_LIBS debug optimized ) 
+
+  filter_lib_list( "${PLUGIN_EXTRA_LINK_LIBS}" FILTERED_LINK_LIBS debug optimized )
   set( LIBRARIES ${LIBRARIES} ${FILTERED_LINK_LIBS} )
-  
+
   target_link_libraries( ${PLUGIN_LIBNAME} PRIVATE ${LIBRARIES} )
-  
+
   install(
     TARGETS ${PLUGIN_LIBNAME}
     DESTINATION lib/plugins

--- a/cmake/plugins.cmake
+++ b/cmake/plugins.cmake
@@ -2,9 +2,7 @@ macro( filter_lib_list INPUT OUTPUT GOOD BAD )
   set( LIB_LST ${INPUT} )
   set( USE_LIB YES )
   foreach( ELEMENT IN LISTS LIB_LST )
-    # A library is defined as:
-    # * <build_type> <lib>
-    # * <lib>
+    # Expected sequence [<build_type>] <lib> [[<build_type>] <lib>] [...]
     if( "${ELEMENT}" STREQUAL "general" OR "${ELEMENT}" STREQUAL "${GOOD}" )
       set( USE_LIB YES )
     elseif( "${ELEMENT}" STREQUAL "${BAD}" )

--- a/cmake/plugins.cmake
+++ b/cmake/plugins.cmake
@@ -2,7 +2,7 @@ macro( filter_lib_list INPUT OUTPUT GOOD BAD )
   set( LIB_LST ${INPUT} )
   set( USE_LIB YES )
   foreach( ELEMENT IN LISTS LIB_LST )
-    # A library is defines as:
+    # A library is defined as:
     # * <build_type> <lib>
     # * <lib>
     if( "${ELEMENT}" STREQUAL "general" OR "${ELEMENT}" STREQUAL "${GOOD}" )


### PR DESCRIPTION
**Problem**

Consider the following libraries:
* A: `hdf5::hdf5-shared`
* B: `debug;/mylibs/debug/libxml2.lib;optimized;/mylibs/libxml2.lib`

The result of the function `filter_lib_list(... debug optimized)` (`cmake/plugins.cmake`) will differ depending on order of libraries:
* AB yields: `hdf5::hdf5-shared;/mylibs/debug/libxml2.lib`
* BA yields: `/mylibs/debug/libxml2.lib`

**Context**

This behavior was discovered while trying to restore a broken MSVS UDA build. With CMake 3.23, `HDF5_LIBRARIES` seems to contain `hdf5::hdf5-shared` rather than a list of libraries accompanied by the library type. Since `hdf5::hdf5-shared` was listed at the end, it was not included among the dependencies and the build failed.
