### PR TITLE
Update _client.py to allow server and port in the Client constructor

### DIFF
--- a/source/wrappers/python/pyuda/_client.py
+++ b/source/wrappers/python/pyuda/_client.py
@@ -53,7 +53,12 @@ class Client(with_metaclass(ClientMeta, object)):
     """
     __metaclass__ = ClientMeta
 
-    def __init__(self, debug_level=logging.ERROR):
+    def __init__(self, server=None, port=None, debug_level=logging.ERROR):
+        if server is not None:
+            self.__class__.server = server
+        if port is not None:
+            self.__class__.port = port
+            
         self.version = __version__
         assert self.version == cpyuda.get_build_version().decode(), "mismatching pyuda and c-library versions"
 


### PR DESCRIPTION
Simplify python client instance creation
```py
pyuda.Client.server = 'my.server.hostname'
pyuda.Client.port = 56789
client = pyuda.Client()
```

Can now we replaced by
```py
client = pyuda.Client('my.server.hostname', 56789)
```