### PR TITLE
Update client_installation.md: add libtirpc-dev dependency for ubuntu

### DIFF
--- a/docs/client_installation.md
+++ b/docs/client_installation.md
@@ -76,6 +76,7 @@ Install dependencies from system package manager.
 ```sh
 sudo apt update && sudo apt install -y \
 git \
+libtirpc-dev \
 libboost-dev \
 libboost-program-options-dev \
 libssl-dev \


### PR DESCRIPTION
`libtirpc-dev` is required for building UDA on Ubuntu, however it isn't installed by default in all Ubuntu images (for instance in the WSL2 distribution for Ubuntu 24.04).