### PR TITLE
76-server_block-idamerrorstackidamerror-and-all-related-methods-are-n…

### DIFF
--- a/source/client/udaClient.cpp
+++ b/source/client/udaClient.cpp
@@ -59,7 +59,7 @@ LOGSTRUCTLIST* g_log_struct_list = nullptr;
 //----------------------------------------------------------------------------------------------------------------------
 
 CLIENT_BLOCK client_block;
-SERVER_BLOCK server_block;
+__thread SERVER_BLOCK server_block;
 
 time_t tv_server_start = 0;
 time_t tv_server_end = 0;
@@ -397,10 +397,14 @@ int idamClient(REQUEST_BLOCK* request_block, int* indices)
     //-------------------------------------------------------------------------
     // Initialise the Error Stack before Accessing Data
 
-    if (tv_server_start != 0) {
+    /*if (tv_server_start != 0) {
+	if(server_block.idamerrorstack.idamerror!=NULL){
+         free(server_block.idamerrorstack.idamerror);
+    	}
+
         freeIdamErrorStack(&server_block.idamerrorstack);    // Free Previous Stack Heap
     }
-
+    */
     initServerBlock(&server_block, 0); // Reset previous Error Messages from the Server & Free Heap
     initUdaErrorStack();
 
@@ -1424,7 +1428,7 @@ void udaFree(int handle)
     }
 
     // closeIdamError(&server_block.idamerrorstack);
-    freeIdamErrorStack(&server_block.idamerrorstack);
+    // freeIdamErrorStack(&server_block.idamerrorstack);
     initDataBlock(data_block);
     data_block->handle = -1;        // Flag this as ready for re-use
 }

--- a/source/client2/client.cpp
+++ b/source/client2/client.cpp
@@ -1022,7 +1022,7 @@ void uda::client::Client::concat_errors(UDA_ERROR_STACK* error_stack)
     unsigned int iold = error_stack->nerrors;
     unsigned int inew = error_stack_.size() + error_stack->nerrors;
 
-    error_stack->idamerror = (UDA_ERROR*)realloc((void*)error_stack->idamerror, (inew * sizeof(UDA_ERROR)));
+    //RC error_stack->idamerror = (UDA_ERROR*)realloc((void*)error_stack->idamerror, (inew * sizeof(UDA_ERROR)));
 
     for (unsigned int i = iold; i < inew; i++) {
         error_stack->idamerror[i] = error_stack_[i - iold];

--- a/source/clientserver/errorLog.cpp
+++ b/source/clientserver/errorLog.cpp
@@ -67,9 +67,11 @@ void initUdaErrorStack()
     udaerrorstack.clear();
 }
 
-void initErrorRecords(const UDA_ERROR_STACK* errorstack)
+//RC void initErrorRecords(const UDA_ERROR_STACK* errorstack)
+void initErrorRecords(UDA_ERROR_STACK* errorstack)
 {
-    for (unsigned int i = 0; i < errorstack->nerrors; i++) {
+    //RC for (unsigned int i = 0; i < errorstack->nerrors; i++) {
+    for (unsigned int i = 0; i < UDA_MAX_ERRORS; i++) {
         errorstack->idamerror[i].type = 0;
         errorstack->idamerror[i].code = 0;
         errorstack->idamerror[i].location[0] = '\0';
@@ -141,8 +143,11 @@ void concatUdaError(UDA_ERROR_STACK* errorstackout)
 
     unsigned int iold = errorstackout->nerrors;
     unsigned int inew = udaerrorstack.size() + errorstackout->nerrors;
+	if (inew > UDA_MAX_ERRORS) {
+		inew = UDA_MAX_ERRORS;
+	}
 
-    errorstackout->idamerror = (UDA_ERROR*)realloc((void*)errorstackout->idamerror, (inew * sizeof(UDA_ERROR)));
+    //RC errorstackout->idamerror = (UDA_ERROR*)realloc((void*)errorstackout->idamerror, (inew * sizeof(UDA_ERROR)));
 
     for (unsigned int i = iold; i < inew; i++) {
         errorstackout->idamerror[i] = udaerrorstack[i - iold];
@@ -154,10 +159,10 @@ void freeIdamErrorStack(UDA_ERROR_STACK* errorstack)
 {
     // "FIX" : this is causing segfaults when using multiple clients (eg. get and put) 
     //         apparently due to both trying to free the same memory. Needs fixing properly.
-    //    free(errorstack->idamerror);
+     //   free(errorstack->idamerror);
       
     errorstack->nerrors = 0;
-    errorstack->idamerror = nullptr;
+    //RC errorstack->idamerror = nullptr;
 }
 
 // Free Stack Heap

--- a/source/clientserver/errorLog.h
+++ b/source/clientserver/errorLog.h
@@ -21,7 +21,8 @@ extern "C" {
 LIBRARY_API int udaNumErrors(void);
 LIBRARY_API void udaErrorLog(CLIENT_BLOCK client_block, REQUEST_BLOCK request_block, UDA_ERROR_STACK* error_stack);
 LIBRARY_API void initUdaErrorStack(void);
-LIBRARY_API void initErrorRecords(const UDA_ERROR_STACK* errorstack);
+//RC LIBRARY_API void initErrorRecords(const UDA_ERROR_STACK* errorstack);
+LIBRARY_API void initErrorRecords(UDA_ERROR_STACK* errorstack);
 LIBRARY_API void printIdamErrorStack(void);
 LIBRARY_API void addIdamError(int type, const char* location, int code, const char* msg);
 LIBRARY_API void concatUdaError(UDA_ERROR_STACK* errorstackout);

--- a/source/clientserver/initStructs.cpp
+++ b/source/clientserver/initStructs.cpp
@@ -96,7 +96,7 @@ void initServerBlock(SERVER_BLOCK* str, int version)
     str->msg[0] = '\0';
     str->pid = (int)getpid();
     str->idamerrorstack.nerrors = 0;
-    str->idamerrorstack.idamerror = nullptr;
+    //RC str->idamerrorstack.idamerror = nullptr;
     str->OSName[0] = '\0';    // Operating System Name
     str->DOI[0] = '\0';    // Digital Object Identifier (server configuration)
 

--- a/source/clientserver/protocol.cpp
+++ b/source/clientserver/protocol.cpp
@@ -76,8 +76,8 @@ int protocol_serv(XDR* xdrs, int protocol_id, int direction, int* token, LOGMALL
 
                     if (server_block->idamerrorstack.nerrors > 0) {    // No Data to Receive?
 
-                        server_block->idamerrorstack.idamerror = (UDA_ERROR*) malloc(
-                                server_block->idamerrorstack.nerrors * sizeof(UDA_ERROR));
+                        //RC server_block->idamerrorstack.idamerror = (UDA_ERROR*) malloc(
+                        //        server_block->idamerrorstack.nerrors * sizeof(UDA_ERROR));
                         initErrorRecords(&server_block->idamerrorstack);
 
                         if (!xdr_server2(xdrs, server_block)) {

--- a/source/clientserver/protocol2.cpp
+++ b/source/clientserver/protocol2.cpp
@@ -308,8 +308,8 @@ static int handle_server_block(XDR* xdrs, int direction, const void* str, int pr
 
             if (server_block->idamerrorstack.nerrors > 0) {    // No Data to Receive?
 
-                server_block->idamerrorstack.idamerror = (UDA_ERROR*)malloc(
-                        server_block->idamerrorstack.nerrors * sizeof(UDA_ERROR));
+                //RC server_block->idamerrorstack.idamerror = (UDA_ERROR*)malloc(
+                //        server_block->idamerrorstack.nerrors * sizeof(UDA_ERROR));
                 initErrorRecords(&server_block->idamerrorstack);
 
                 if (!xdr_server2(xdrs, server_block)) {

--- a/source/clientserver/udaStructs.h
+++ b/source/clientserver/udaStructs.h
@@ -306,9 +306,11 @@ typedef struct UdaError {
     char msg[STRING_LENGTH];        // Message
 } UDA_ERROR;
 
+#define UDA_MAX_ERRORS 30
+
 typedef struct UdaErrorStack {
     unsigned int nerrors;           // Number of Errors
-    UDA_ERROR* idamerror;           // Array of Errors
+    UDA_ERROR idamerror[UDA_MAX_ERRORS];           // Array of Errors
 } UDA_ERROR_STACK;
 
 typedef struct ServerBlock {

--- a/source/plugins/udaPlugin.cpp
+++ b/source/plugins/udaPlugin.cpp
@@ -40,7 +40,7 @@ IDAM_PLUGIN_INTERFACE* udaCreatePluginInterface(const char* request)
     plugin_interface->housekeeping = 0;
     plugin_interface->changePlugin = 0;
     plugin_interface->error_stack.nerrors = 0;
-    plugin_interface->error_stack.idamerror = nullptr;
+    //RC plugin_interface->error_stack.idamerror = nullptr;
 
     return plugin_interface;
 }

--- a/source/server/serverGetData.cpp
+++ b/source/server/serverGetData.cpp
@@ -1089,7 +1089,7 @@ int read_data(REQUEST_DATA* request, CLIENT_BLOCK client_block,
         idam_plugin_interface.userdefinedtypelist = userdefinedtypelist;
         idam_plugin_interface.logmalloclist = logmalloclist;
         idam_plugin_interface.error_stack.nerrors = 0;
-        idam_plugin_interface.error_stack.idamerror = nullptr;
+        //RC idam_plugin_interface.error_stack.idamerror = nullptr;
 
         int plugin_id;
 

--- a/source/server/serverPlugin.cpp
+++ b/source/server/serverPlugin.cpp
@@ -446,7 +446,7 @@ int udaProvenancePlugin(CLIENT_BLOCK* client_block, REQUEST_DATA* original_reque
     idam_plugin_interface.userdefinedtypelist = &userdefinedtypelist;
     idam_plugin_interface.logmalloclist = &logmalloclist;
     idam_plugin_interface.error_stack.nerrors = 0;
-    idam_plugin_interface.error_stack.idamerror = nullptr;
+    //RC idam_plugin_interface.error_stack.idamerror = nullptr;
 
     // Redirect Output to temporary file if no file handles passed
 
@@ -593,7 +593,7 @@ int udaServerMetaDataPlugin(const PLUGINLIST* plugin_list, int plugin_id, REQUES
     idam_plugin_interface.userdefinedtypelist = &userdefinedtypelist;
     idam_plugin_interface.logmalloclist = &logmalloclist;
     idam_plugin_interface.error_stack.nerrors = 0;
-    idam_plugin_interface.error_stack.idamerror = nullptr;
+    //RC idam_plugin_interface.error_stack.idamerror = nullptr;
 
     // Redirect Output to temporary file if no file handles passed
 

--- a/source/server2/get_data.cpp
+++ b/source/server2/get_data.cpp
@@ -1052,7 +1052,7 @@ int uda::Server::read_data(RequestData* request, DATA_BLOCK* data_block)
         plugin_interface.userdefinedtypelist = user_defined_type_list_;
         plugin_interface.logmalloclist = log_malloc_list_;
         plugin_interface.error_stack.nerrors = 0;
-        plugin_interface.error_stack.idamerror = nullptr;
+        //RC plugin_interface.error_stack.idamerror = nullptr;
 
         int plugin_request = REQUEST_READ_UNKNOWN;
 

--- a/source/server2/server_plugin.cpp
+++ b/source/server2/server_plugin.cpp
@@ -361,7 +361,7 @@ int uda::provenancePlugin(ClientBlock* client_block, RequestData* original_reque
     plugin_interface.userdefinedtypelist = &userdefinedtypelist;
     plugin_interface.logmalloclist = &logmalloclist;
     plugin_interface.error_stack.nerrors = 0;
-    plugin_interface.error_stack.idamerror = nullptr;
+    //RC plugin_interface.error_stack.idamerror = nullptr;
 
     // Redirect Output to temporary file if no file handles passed
 
@@ -511,7 +511,7 @@ int uda::call_metadata_plugin(const PluginData& plugin, RequestData* request_blo
     idam_plugin_interface.userdefinedtypelist = &userdefinedtypelist;
     idam_plugin_interface.logmalloclist = &logmalloclist;
     idam_plugin_interface.error_stack.nerrors = 0;
-    idam_plugin_interface.error_stack.idamerror = nullptr;
+    //RC idam_plugin_interface.error_stack.idamerror = nullptr;
 
     // Redirect Output to temporary file if no file handles passed
 


### PR DESCRIPTION
A possible fix based on:
1 Instantiating a server block per thread
udaClient.cpp:__thread SERVER_BLOCK server_block;

2. Doing idamerror as static array
udaStructs.h:    UDA_ERROR idamerror[UDA_MAX_ERRORS];           // Array of Errors

