### PR TITLE
Bugfix/repeated bytes calls fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,6 @@ build_idl84:
     - cp -r install/lib/python${PYTHON_VERSION}/site-packages/*uda* dist
 
     - export PYTHONPATH=dist:$PYTHONPATH
-    # - export LD_LIBRARY_PATH=install/lib:$LD_LIBRARY_PATH
     - module use install/modulefiles
     - UDA_MODULE=`ls install/modulefiles | grep uda`
     - module load $UDA_MODULE
@@ -76,6 +75,7 @@ build_idl84:
     - python3 -m pytest -v mastcodes/uda/python/tests/test_uda_meta.py
     - python3 -m pytest -v mastcodes/uda/python/tests/test_uda_signals.py
     - python3 -m pytest -v mastcodes/uda/python/tests/test_uda_xpad.py
+    - python3 tests/test_put.py
   artifacts:
     paths:
       - dist

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,7 +75,7 @@ build_idl84:
     - python3 -m pytest -v mastcodes/uda/python/tests/test_uda_meta.py
     - python3 -m pytest -v mastcodes/uda/python/tests/test_uda_signals.py
     - python3 -m pytest -v mastcodes/uda/python/tests/test_uda_xpad.py
-    - python3 tests/test_put.py
+    - python3 mastcodes/uda/python/tests/test_put.py
   artifacts:
     paths:
       - dist

--- a/source/plugins/bytes/bytesPlugin.cpp
+++ b/source/plugins/bytes/bytesPlugin.cpp
@@ -237,7 +237,7 @@ int BytesPlugin::read(IDAM_PLUGIN_INTERFACE* plugin_interface)
     int max_bytes = -1;
     FIND_INT_VALUE(plugin_interface->request_data->nameValueList, max_bytes);
 
-    unsigned long offset = -1;
+    unsigned long offset = 0;
     FIND_UNSIGNED_LONG_VALUE(plugin_interface->request_data->nameValueList, offset);
     auto file_size = filesystem::file_size(path);
     if (offset > file_size) {

--- a/source/plugins/bytes/bytesPlugin.cpp
+++ b/source/plugins/bytes/bytesPlugin.cpp
@@ -240,7 +240,7 @@ int BytesPlugin::read(IDAM_PLUGIN_INTERFACE* plugin_interface)
     unsigned long offset = 0;
     FIND_UNSIGNED_LONG_VALUE(plugin_interface->request_data->nameValueList, offset);
     auto file_size = filesystem::file_size(path);
-    if (offset > file_size) {
+    if (offset >= file_size) {
         RAISE_PLUGIN_ERROR_AND_EXIT("Offset specified is out of bounds", plugin_interface);
     }
 

--- a/source/plugins/bytes/bytesPlugin.cpp
+++ b/source/plugins/bytes/bytesPlugin.cpp
@@ -3,7 +3,9 @@
 #include <clientserver/stringUtils.h>
 #include <clientserver/makeRequestBlock.h>
 #include <clientserver/initStructs.h>
+#include <exception>
 #include <plugins/utils.h>
+#include <stdexcept>
 #include <version.h>
 
 #include "readBytesNonOptimally.h"
@@ -62,6 +64,7 @@ public:
             return;
         }
         // Free Heap & reset counters
+        file_map_.clear();
         init_ = false;
     }
 
@@ -82,50 +85,57 @@ private:
 
 int bytesPlugin(IDAM_PLUGIN_INTERFACE* plugin_interface)
 {
-    static BytesPlugin plugin = {};
+    try {
+        static BytesPlugin plugin = {};
 
-    if (plugin_interface->interfaceVersion > THISPLUGIN_MAX_INTERFACE_VERSION) {
-        RAISE_PLUGIN_ERROR("Plugin Interface Version Unknown to this plugin: Unable to execute the request!");
-    }
+        if (plugin_interface->interfaceVersion > THISPLUGIN_MAX_INTERFACE_VERSION) {
+            RAISE_PLUGIN_ERROR("Plugin Interface Version Unknown to this plugin: Unable to execute the request!");
+        }
 
-    plugin_interface->pluginVersion = THISPLUGIN_VERSION;
+        plugin_interface->pluginVersion = THISPLUGIN_VERSION;
 
-    REQUEST_DATA* request = plugin_interface->request_data;
+        REQUEST_DATA* request = plugin_interface->request_data;
 
-    if (plugin_interface->housekeeping || STR_IEQUALS(request->function, "reset")) {
-        plugin.reset(plugin_interface);
-        return 0;
-    }
+        if (plugin_interface->housekeeping || STR_IEQUALS(request->function, "reset")) {
+            plugin.reset(plugin_interface);
+            return 0;
+        }
 
-    plugin.init(plugin_interface);
-    if (STR_IEQUALS(request->function, "init")
-        || STR_IEQUALS(request->function, "initialise")) {
-        return 0;
-    }
+        plugin.init(plugin_interface);
+        if (STR_IEQUALS(request->function, "init")
+                || STR_IEQUALS(request->function, "initialise")) {
+            return 0;
+        }
 
-    //----------------------------------------------------------------------------------------
-    // Plugin Functions
-    //----------------------------------------------------------------------------------------
+        //----------------------------------------------------------------------------------------
+        // Plugin Functions
+        //----------------------------------------------------------------------------------------
 
-    //----------------------------------------------------------------------------------------
-    // Standard methods: version, builddate, defaultmethod, maxinterfaceversion
+        //----------------------------------------------------------------------------------------
+        // Standard methods: version, builddate, defaultmethod, maxinterfaceversion
 
-    if (STR_IEQUALS(request->function, "help")) {
-        return plugin.help(plugin_interface);
-    } else if (STR_IEQUALS(request->function, "version")) {
-        return plugin.version(plugin_interface);
-    } else if (STR_IEQUALS(request->function, "builddate")) {
-        return plugin.build_date(plugin_interface);
-    } else if (STR_IEQUALS(request->function, "defaultmethod")) {
-        return plugin.default_method(plugin_interface);
-    } else if (STR_IEQUALS(request->function, "maxinterfaceversion")) {
-        return plugin.max_interface_version(plugin_interface);
-    } else if (STR_IEQUALS(request->function, "read")) {
-        return plugin.read(plugin_interface);
-    } else if (STR_IEQUALS(request->function, "size")) {
-        return plugin.size(plugin_interface);
-    } else {
-        RAISE_PLUGIN_ERROR_AND_EXIT("Unknown function requested!", plugin_interface);
+        if (STR_IEQUALS(request->function, "help")) {
+            return plugin.help(plugin_interface);
+        } else if (STR_IEQUALS(request->function, "version")) {
+            return plugin.version(plugin_interface);
+        } else if (STR_IEQUALS(request->function, "builddate")) {
+            return plugin.build_date(plugin_interface);
+        } else if (STR_IEQUALS(request->function, "defaultmethod")) {
+            return plugin.default_method(plugin_interface);
+        } else if (STR_IEQUALS(request->function, "maxinterfaceversion")) {
+            return plugin.max_interface_version(plugin_interface);
+        } else if (STR_IEQUALS(request->function, "read")) {
+            return plugin.read(plugin_interface);
+        } else if (STR_IEQUALS(request->function, "size")) {
+            return plugin.size(plugin_interface);
+        } else {
+            RAISE_PLUGIN_ERROR_AND_EXIT("Unknown function requested!", plugin_interface);
+        }
+    } catch (const std::exception& e) {
+        std::string err_msg = std::string("Excption raised in bytes plugin:") + e.what();
+        RAISE_PLUGIN_ERROR_AND_EXIT(err_msg.c_str(), plugin_interface);
+    } catch (...) {
+        RAISE_PLUGIN_ERROR_AND_EXIT("Unknown exception raised by bytes plugin", plugin_interface);
     }
 }
 
@@ -227,8 +237,12 @@ int BytesPlugin::read(IDAM_PLUGIN_INTERFACE* plugin_interface)
     int max_bytes = -1;
     FIND_INT_VALUE(plugin_interface->request_data->nameValueList, max_bytes);
 
-    int offset = -1;
-    FIND_INT_VALUE(plugin_interface->request_data->nameValueList, offset);
+    unsigned long offset = -1;
+    FIND_UNSIGNED_LONG_VALUE(plugin_interface->request_data->nameValueList, offset);
+    auto file_size = filesystem::file_size(path);
+    if (offset > file_size) {
+        RAISE_PLUGIN_ERROR_AND_EXIT("Offset specified is out of bounds", plugin_interface);
+    }
 
     const char* checksum = nullptr;
     FIND_STRING_VALUE(plugin_interface->request_data->nameValueList, checksum);

--- a/source/plugins/bytes/readBytesNonOptimally.cpp
+++ b/source/plugins/bytes/readBytesNonOptimally.cpp
@@ -55,12 +55,9 @@ int readBytes(FILE* fh, DATA_BLOCK* data_block, int offset, int max_bytes, const
 
     data_block->data_n = buf_size;    // 1 less than no. bytes read: Last Byte is an EOF
 
-    if (offset > 0) {
+    if (offset >= 0) {
         fseek(fh, offset, SEEK_SET);
-    } else {
-        fseek(fh, 0, SEEK_SET);
     }
-
 
     char* bp = nullptr;
     while (!feof(fh)) {

--- a/source/plugins/bytes/readBytesNonOptimally.cpp
+++ b/source/plugins/bytes/readBytesNonOptimally.cpp
@@ -55,15 +55,18 @@ int readBytes(FILE* fh, DATA_BLOCK* data_block, int offset, int max_bytes, const
 
     data_block->data_n = buf_size;    // 1 less than no. bytes read: Last Byte is an EOF
 
-    if (offset >= 0) {
+    if (offset > 0) {
         fseek(fh, offset, SEEK_SET);
+    } else {
+        fseek(fh, 0, SEEK_SET);
     }
+
 
     char* bp = nullptr;
     while (!feof(fh)) {
         char* newp = (char*)realloc(bp, (size_t)data_block->data_n);
         if (newp == nullptr) {
-            free(bp);
+            if (bp != nullptr) free(bp);
             err = BYTE_FILE_HEAP_ERROR;
             addIdamError(UDA_CODE_ERROR_TYPE, "readBytes", err, "Unable to Allocate Heap Memory for the File");
             break;

--- a/source/plugins/udaPlugin.cpp
+++ b/source/plugins/udaPlugin.cpp
@@ -468,6 +468,51 @@ bool findIntValue(const NAMEVALUELIST* namevaluelist, int* value, const char* na
 }
 
 /**
+ * Look for an argument with the given name in the provided NAMEVALUELIST and return it's associate value as a long integer.
+ *
+ * If the argument is found the value associated with the argument is provided via the value parameter and the function
+ * returns 1. Otherwise value is not set and the function returns 0.
+ * @param namevaluelist
+ * @param value
+ * @param name
+ * @return
+ */
+bool findLongIntValue(const NAMEVALUELIST* namevaluelist, long* value, const char* name)
+{
+    const char* str;
+    bool found = findStringValue(namevaluelist, &str, name);
+    if (found) {
+        *value = atol(str);
+    }
+    return found;
+}
+
+/**
+ * Look for an argument with the given name in the provided NAMEVALUELIST and return it's associate value as an
+ *  unsigned long integer.
+ *
+ * If the argument is found the value associated with the argument is provided via the value parameter and the function
+ * returns 1. Otherwise value is not set and the function returns 0.
+ * @param namevaluelist
+ * @param value
+ * @param name
+ * @return
+ */
+bool findUnsignedLongValue(const NAMEVALUELIST* namevaluelist, unsigned long* value, const char* name)
+{
+    const char* str;
+    bool found = findStringValue(namevaluelist, &str, name);
+    if (found) {
+        if (std::strchr(str, '-') != nullptr) {
+            RAISE_PLUGIN_ERROR("Negative value found when unsigned expected");
+            return false;
+        }
+        *value = std::strtoul(str, nullptr, 10);
+    }
+    return found;
+}
+
+/**
  * Look for an argument with the given name in the provided NAMEVALUELIST and return it's associate value as a short.
  *
  * If the argument is found the value associated with the argument is provided via the value parameter and the function

--- a/source/plugins/udaPlugin.cpp
+++ b/source/plugins/udaPlugin.cpp
@@ -14,6 +14,7 @@
 #include <type_traits>
 #include <regex>
 #include <string>
+#include <cstring>
 
 IDAM_PLUGIN_INTERFACE* udaCreatePluginInterface(const char* request)
 {

--- a/source/plugins/udaPlugin.cpp
+++ b/source/plugins/udaPlugin.cpp
@@ -505,7 +505,8 @@ bool findUnsignedLongValue(const NAMEVALUELIST* namevaluelist, unsigned long* va
     bool found = findStringValue(namevaluelist, &str, name);
     if (found) {
         if (std::strchr(str, '-') != nullptr) {
-            RAISE_PLUGIN_ERROR("Negative value found when unsigned expected");
+            std::string err_msg = std::string("Negative value found when unsigned expected: ") + name + "=" + str;
+            RAISE_PLUGIN_ERROR(err_msg.c_str());
             return false;
         }
         *value = std::strtoul(str, nullptr, 10);

--- a/source/plugins/udaPlugin.h
+++ b/source/plugins/udaPlugin.h
@@ -83,6 +83,8 @@ LIBRARY_API int setReturnData(DATA_BLOCK* data_block, void* value, size_t size, 
 LIBRARY_API bool findStringValue(const NAMEVALUELIST* namevaluelist, const char** value, const char* name);
 LIBRARY_API bool findValue(const NAMEVALUELIST* namevaluelist, const char* name);
 LIBRARY_API bool findIntValue(const NAMEVALUELIST* namevaluelist, int* value, const char* name);
+LIBRARY_API bool findLongIntValue(const NAMEVALUELIST* namevaluelist, long* value, const char* name);
+LIBRARY_API bool findUnsignedLongValue(const NAMEVALUELIST* namevaluelist, unsigned long* value, const char* name);
 LIBRARY_API bool findShortValue(const NAMEVALUELIST* namevaluelist, short* value, const char* name);
 LIBRARY_API bool findCharValue(const NAMEVALUELIST* namevaluelist, char* value, const char* name);
 LIBRARY_API bool findFloatValue(const NAMEVALUELIST* namevaluelist, float* values, const char* name);
@@ -142,6 +144,8 @@ if (!find##TYPE##Array(&NAME_VALUE_LIST, &VARIABLE, CONCAT(&n, VARIABLE), QUOTE(
 }
 
 #define FIND_REQUIRED_INT_VALUE(NAME_VALUE_LIST, VARIABLE)      FIND_REQUIRED_VALUE(NAME_VALUE_LIST, VARIABLE, Int)
+#define FIND_REQUIRED_LONG_VALUE(NAME_VALUE_LIST, VARIABLE)      FIND_REQUIRED_VALUE(NAME_VALUE_LIST, VARIABLE, LongInt)
+#define FIND_REQUIRED_UNSIGNED_LONG_VALUE(NAME_VALUE_LIST, VARIABLE)      FIND_REQUIRED_VALUE(NAME_VALUE_LIST, VARIABLE, UnsignedLong)
 #define FIND_REQUIRED_SHORT_VALUE(NAME_VALUE_LIST, VARIABLE)    FIND_REQUIRED_VALUE(NAME_VALUE_LIST, VARIABLE, Short)
 #define FIND_REQUIRED_CHAR_VALUE(NAME_VALUE_LIST, VARIABLE)     FIND_REQUIRED_VALUE(NAME_VALUE_LIST, VARIABLE, Char)
 #define FIND_REQUIRED_FLOAT_VALUE(NAME_VALUE_LIST, VARIABLE)    FIND_REQUIRED_VALUE(NAME_VALUE_LIST, VARIABLE, Float)
@@ -152,6 +156,8 @@ if (!find##TYPE##Array(&NAME_VALUE_LIST, &VARIABLE, CONCAT(&n, VARIABLE), QUOTE(
 #define FIND_REQUIRED_DOUBLE_ARRAY(NAME_VALUE_LIST, VARIABLE)    FIND_REQUIRED_ARRAY(NAME_VALUE_LIST, VARIABLE, Double)
 
 #define FIND_INT_VALUE(NAME_VALUE_LIST, VARIABLE)       findIntValue(&NAME_VALUE_LIST, &VARIABLE, QUOTE(VARIABLE))
+#define FIND_LONG_VALUE(NAME_VALUE_LIST, VARIABLE)       findLongIntValue(&NAME_VALUE_LIST, &VARIABLE, QUOTE(VARIABLE))
+#define FIND_UNSIGNED_LONG_VALUE(NAME_VALUE_LIST, VARIABLE)       findUnsignedLongValue(&NAME_VALUE_LIST, &VARIABLE, QUOTE(VARIABLE))
 #define FIND_SHORT_VALUE(NAME_VALUE_LIST, VARIABLE)     findShortValue(&NAME_VALUE_LIST, &VARIABLE, QUOTE(VARIABLE))
 #define FIND_CHAR_VALUE(NAME_VALUE_LIST, VARIABLE)      findCharValue(&NAME_VALUE_LIST, &VARIABLE, QUOTE(VARIABLE))
 #define FIND_FLOAT_VALUE(NAME_VALUE_LIST, VARIABLE)     findFloatValue(&NAME_VALUE_LIST, &VARIABLE, QUOTE(VARIABLE))

--- a/source/wrappers/python/README.md
+++ b/source/wrappers/python/README.md
@@ -19,4 +19,4 @@ signal_object = client.get(signal, source)
 ```
 
 ## Old release versions
-Releases 2.7.6-2.8.1 were uploaded to the uda project on pypi [here](https://pypi.org/project/uda). The project moved here under the pyuda name for release 2.8.2. 
+Releases 2.7.6-2.8.1 were uploaded to the uda project on pypi [here](https://pypi.org/project/uda). The project moved here under the pyuda name for release 2.9.0.

--- a/source/wrappers/python/pyuda/_client.py
+++ b/source/wrappers/python/pyuda/_client.py
@@ -117,7 +117,7 @@ class Client(with_metaclass(ClientMeta, object)):
             chunk_size = 0
 
         if chunk_size:
-            result = cpyuda.get_data("bytes::size(path={path})".format(path=source_file) % source_file, "")
+            result = cpyuda.get_data("bytes::size(path={path})".format(path=source_file), "")
             size = result.data()
             chunk_size = int(chunk_size * 1024 * 1024)
             count = 0

--- a/source/wrappers/python/uda/README.md
+++ b/source/wrappers/python/uda/README.md
@@ -7,7 +7,7 @@ Install the new package directly using:
 pip install pyuda
 ```
 
-Previous release versions (2.7.6-2.8.1) are still hosted here. The first release under the new pyuda name is 2.8.2. 
+Previous release versions (2.7.6-2.8.1) are still hosted here. The first release under the new pyuda name is 2.9.0.
 
 ## Pyuda package description
 


### PR DESCRIPTION
Cached file-handle pointed to end of file after first call to bytes plugin. If called again on the same file this was not reset to the beginning by default. Main change is to reset the pointer to the beginning of the file by default.

Also:
- adds try/catch in the C/C++ interface function as throwing functions now exist from std::filesystem. 
- changes offset datatype from int to unsigned long (would have had a maximum size of ~2GB before) 
- checks for nullptr before freeing for the out-of-memory error case