### PR TITLE
Add debug log for cached requests in idamClient

### DIFF
--- a/source/client/udaClient.cpp
+++ b/source/client/udaClient.cpp
@@ -458,6 +458,7 @@ int idamClient(REQUEST_BLOCK* request_block, int* indices)
                 continue;
             }
         }
+        UDA_LOG(UDA_LOG_DEBUG, "Number of cached requests: %d\n", num_cached);
 #  endif // !NOLIBMEMCACHED
 
         //-------------------------------------------------------------------------


### PR DESCRIPTION
Hello!

Whan I compiled the UDA client, I ran into the following error:
```bash
$SRC_DIR/source/client/udaClient.cpp:442:13: error: variable 'num_cached' set but not used [-Werror,-Wunused-but-set-variable]
  442 |         int num_cached = 0;
      |             ^
1 error generated.
```

To use this variable outside the for loop statement as well, I would like to introduce a debug log to track the number of cached requests in the idamClient function.
I would appreciate it if you could confirm whether this handling is correct.