### PR TITLE
🛠️ Remove C++17 standard flag from pkg-config files

### DIFF
--- a/source/etc/uda-cpp.pc.in
+++ b/source/etc/uda-cpp.pc.in
@@ -8,6 +8,6 @@ Name: UDA
 Description: The Universal Data Access library
 URL: https://ukaea.github.io/UDA/
 Version: @PROJECT_VERSION@
-Cflags: -std=c++17 -I${includedir} -I${includedir}/c++ @PKGCONFIG_INCLUDES@
+Cflags: -I${includedir} -I${includedir}/c++ @PKGCONFIG_INCLUDES@
 Libs: -L${libdir} -luda_cpp @PKGCONFIG_LIBRARIES@
 Requires: @PKGCONFIG_REQUIRES@

--- a/source/etc/uda-fat-cpp.pc.in
+++ b/source/etc/uda-fat-cpp.pc.in
@@ -8,6 +8,6 @@ Name: UDA
 Description: The Universal Data Access library
 URL: https://ukaea.github.io/UDA/
 Version: @PROJECT_VERSION@
-Cflags: -DFATCLIENT -std=c++17 -I${includedir} -I${includedir}/c++ @PKGCONFIG_INCLUDES@
+Cflags: -DFATCLIENT -I${includedir} -I${includedir}/c++ @PKGCONFIG_INCLUDES@
 Libs: -L${libdir} -lfatuda_cpp @PKGCONFIG_LIBRARIES@
 Requires: @PKGCONFIG_REQUIRES@


### PR DESCRIPTION
Hello

I suggest removing the `-std=c++17` flag because it can cause conflicts with other dependencies that use a different C++ standard.
This was discussed [here](https://stackoverflow.com/questions/46550299/why-doesnt-pkg-config-support-cxxflags?utm_source=chatgpt.com) as well.