### PR TITLE
Add DLL export symbols and fix formatting

### DIFF
--- a/source/clientserver/udaStructs.h
+++ b/source/clientserver/udaStructs.h
@@ -430,7 +430,7 @@ typedef struct Environment {
 
 void freeClientPutDataBlockList(PUTDATA_BLOCK_LIST* putDataBlockList);
 
-void freeDataBlock(DATA_BLOCK* data_block);
+LIBRARY_API void freeDataBlock(DATA_BLOCK* data_block);
 
 void freeDataBlockList(DATA_BLOCK_LIST* data_block_list);
 

--- a/source/wrappers/c++/client.hpp
+++ b/source/wrappers/c++/client.hpp
@@ -151,7 +151,7 @@ public:
     static std::string serverHostName();
     static int serverPort();
 
-    const char *getErrorMsg(int handle); 
+    const char *getErrorMsg(int handle);
 
     const uda::Result& get(const std::string& signalName, const std::string& dataSource);
 
@@ -161,7 +161,7 @@ public:
     int getFileID(int handle);
 
     int put(const uda::Signal& putdata);
-    
+
     int put(const std::string& instruction);
 
     int put(const std::string& instruction, char data);

--- a/source/wrappers/c++/client.hpp
+++ b/source/wrappers/c++/client.hpp
@@ -124,7 +124,7 @@ class Result;
 class Signal;
 class Client;
 
-class ResultList {
+class LIBRARY_API ResultList {
 public:
     ResultList(std::unordered_map<int, size_t> indices, Client& client);
     const Result& at(int handle) const;


### PR DESCRIPTION
Hello,

When I compile the `imas-core` library with the UDA backend on Windows, I encounter linker errors caused by unexported symbols.

Below, I show where each unexported symbol is used in the `imas-core` sources.

`freeDataBlock`
https://github.com/iterorganization/IMAS-Core/blob/develop/src/uda/uda_backend.cpp#L882

`ResultList`
https://github.com/iterorganization/IMAS-Core/blob/develop/src/uda/uda_backend.cpp#L874

I would appreciate it if you would review it and let me know if other symbols should be exported.